### PR TITLE
chore: set NODE_ENV=production in server Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:22-alpine
 USER node
 WORKDIR /home/node
+ENV NODE_ENV=production
 COPY --chown=node:node package*.json ./
-RUN npm install
+RUN npm install --omit=dev
 COPY --chown=node:node . .
 EXPOSE 1337
 CMD ["node", "index.mjs"]


### PR DESCRIPTION
## Summary

- Adds `ENV NODE_ENV=production` to `server/Dockerfile` so Express runs in production mode during profiling sessions
- Adds `--omit=dev` to `npm install` to exclude dev dependencies from the image

Without this, Express defaults to `development` mode (view-cache disabled, verbose error output, slower middleware paths), meaning profiled latency numbers include dev-mode overhead rather than production characteristics.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)