### PR TITLE
fix: add explicit proxy_read_timeout and upstream keepalive to nginx.conf

### DIFF
--- a/load-balancer/nginx.conf
+++ b/load-balancer/nginx.conf
@@ -5,6 +5,7 @@ http {
     server onesec:1337;
     server fivesec:1337;
     server tensec:1337;
+    keepalive 32;
   }
   server {
     listen 8080;
@@ -12,6 +13,9 @@ http {
     location / {
        proxy_pass http://backends;
        proxy_set_header Host $host;
+       proxy_read_timeout 30s;
+       proxy_http_version 1.1;
+       proxy_set_header Connection "";
     }
   }
     log_format main_ext '[$time_local] $request -$upstream_addr returned $status in $request_time seconds';


### PR DESCRIPTION
## Summary

- Adds `proxy_read_timeout 30s` — explicit timeout with headroom above the 10s max simulated backend, prevents silent 504s if the delay is increased, and makes the config self-documenting for a latency-measurement project
- Adds `keepalive 32` to the upstream block plus `proxy_http_version 1.1` and `proxy_set_header Connection ""` — eliminates per-request TCP handshake overhead so profiling numbers reflect real-world keepalive performance

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)