### PR TITLE
fix(ci): add least-privilege permissions to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

Added `permissions: contents: read` at the top level of `.github/workflows/ci.yml`.

## Why

GitHub Actions workflows without an explicit `permissions` block inherit the default GITHUB_TOKEN scope, which includes broad write access (write to contents, packages, deployments, etc.). This triggered a `actions/missing-workflow-permissions` code scanning alert in the repository's security tab.

This CI workflow only needs to read the repository checkout — it runs syntax checks, `npm ci --audit`, and `docker compose config`. Restricting to `contents: read` follows the principle of least privilege and closes the open security alert.

## Reviewer notes

- No functional change to what the workflow does; only the token's permissions are narrowed.
- Alert: [actions/missing-workflow-permissions #2](https://github.com/bushidocodes/nginx-profiling/security/code-scanning/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)